### PR TITLE
Change API parameter 'after' to 'since'

### DIFF
--- a/mtnhubsnow/MountainHubAPI.py
+++ b/mtnhubsnow/MountainHubAPI.py
@@ -113,7 +113,7 @@ def snow_data(publisher='all', obs_type='snow_conditions,snowpack_test',
         'publisher': publisher,
         'obs_type': obs_type,
         'limit': limit,
-        'after': datetime_to_timestampms(start),
+        'since': datetime_to_timestampms(start),
         'before': datetime_to_timestampms(end),
         **_make_bbox(bbox)
     })

--- a/notebooks/AlaskaRequest_withFoliumMap.ipynb
+++ b/notebooks/AlaskaRequest_withFoliumMap.ipynb
@@ -716,7 +716,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Change API parameter 'after' to 'since', to reflect current API. Requests were failing since the changeover in MH management.